### PR TITLE
Update EggDriveXmlRpcConnector.cs

### DIFF
--- a/src/EggDriveXmlRpcConnector.cs
+++ b/src/EggDriveXmlRpcConnector.cs
@@ -134,7 +134,7 @@ namespace TestPlant.EggDriver
 		private string url = "http://localhost:5400";
 		private readonly IEggDrive proxy = XmlRpcProxyGen.Create<IEggDrive>();
 
-		protected interface IEggDrive : IXmlRpcProxy
+		public interface IEggDrive : IXmlRpcProxy
 		{
 			[XmlRpcMethod("StartSession")]
 			void StartSession();


### PR DESCRIPTION
changed access modifier of IEggDrive from protected to public to solve an issue that AssemblyBuilder was not able to create the Proxy Type